### PR TITLE
Refactor used and required plugins

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,8 +14,12 @@
     vimAlias = true;
     vimdiffAlias = true;
     plugins = with pkgs.vimPlugins; [
+      ## lazyvim base
       LazyVim
       lazy-nvim
+
+      ## ui
+      snacks-nvim ## required
 
       ## additional plugins
       modus-themes-nvim

--- a/lua/plugins/disabled.lua
+++ b/lua/plugins/disabled.lua
@@ -64,8 +64,6 @@ return {
   { "windwp/nvim-ts-autotag",                      enabled = false },
 
   -- UI
-  -- nvim-notify
-  { "rcarriga/nvim-notify",                        enabled = false },
   -- bufferline.nvim
   { "akinsho/bufferline.nvim",                     enabled = false },
   -- lualine.nvim
@@ -78,8 +76,8 @@ return {
   { "echasnovski/mini.icons",                      enabled = false },
   -- nui.nvim
   { "MunifTanjim/nui.nvim",                        enabled = false },
-  --dashboard-nvim
-  { "nvimdev/dashboard-nvim",                      enabled = false },
+  -- snacks.nvim
+  { "folke/snacks.nvim",                           enabled = true },
 
   -- UTIL
   -- persistence.nvim


### PR DESCRIPTION
[LazyVim v13](https://www.lazyvim.org/news#13x) comes with a couple of changes.

LazyVim now uses:

* Snacks.dashboard as the default dashboard
* Snacks.notifier for notifications instead of nvim-notify
*  Snacks.terminal is similar to lazyterm, but has more features and creates bottom splits by default (similar to the edgy integrating)